### PR TITLE
Ensure Supabase config is defined and fix auth effect

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -34,7 +34,7 @@ const InitialLayout = () => {
         } else if (!session && !inAuthFlow) {
             router.replace('/(auth)/login');
         }
-    }, [session, isLoading, router]);
+    }, [session, isLoading, router, segments]);
 
     useEffect(() => {
         if (session?.user?.id) {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -5,6 +5,11 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
+// Ensure the required environment variables are set before creating the client.
+if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Missing Supabase environment variables');
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     auth: {
         storage: AsyncStorage, // Use AsyncStorage for storing session tokens in React Native


### PR DESCRIPTION
## Summary
- prevent Supabase client from initializing when environment variables are missing
- include navigation segments in auth redirect effect dependencies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c6251234832493004239ad371d98