### PR TITLE
feat: add web push notifications

### DIFF
--- a/app/(tabs)/add-job.tsx
+++ b/app/(tabs)/add-job.tsx
@@ -239,6 +239,14 @@ export default function AddJobScreen() {
             await supabase.rpc('decrement_job_quota', { farm_id_input: session.user.id });
             if (isUrgent) {
                 await supabase.rpc('decrement_sos_quota', { farm_id_input: session.user.id });
+                // Notify all workers about the urgent job
+                await supabase.functions.invoke('notify', {
+                    body: {
+                        broadcast: true,
+                        title: t('addJob.urgentNotificationTitle', { defaultValue: 'Urgent job posted' }),
+                        body: title,
+                    },
+                });
             }
 
             Alert.alert(t('addJob.alertSuccess'), t('addJob.alertSuccessMessage'));

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,21 @@
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-messaging-compat.js');
+
+// TODO: Replace with your app's Firebase project configuration
+firebase.initializeApp({
+  apiKey: 'REPLACE_WITH_API_KEY',
+  authDomain: 'REPLACE_WITH_AUTH_DOMAIN',
+  projectId: 'REPLACE_WITH_PROJECT_ID',
+  storageBucket: 'REPLACE_WITH_STORAGE_BUCKET',
+  messagingSenderId: 'REPLACE_WITH_MESSAGING_SENDER_ID',
+  appId: 'REPLACE_WITH_APP_ID',
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const { title, body } = payload.notification || {};
+  self.registration.showNotification(title || 'Notification', {
+    body,
+  });
+});

--- a/supabase/functions/notify/index.ts
+++ b/supabase/functions/notify/index.ts
@@ -1,0 +1,71 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { Expo } from 'https://esm.sh/expo-server-sdk@4';
+
+interface Payload {
+  user_id?: string;
+  broadcast?: boolean;
+  title: string;
+  body: string;
+}
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const fcmKey = Deno.env.get('FCM_SERVER_KEY');
+
+serve(async (req) => {
+  const payload: Payload = await req.json();
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  let query = supabase.from('profiles').select('id, push_token');
+  if (payload.broadcast) {
+    query = query.not('push_token', 'is', null);
+  } else if (payload.user_id) {
+    query = query.eq('id', payload.user_id);
+  } else {
+    return new Response('No recipients', { status: 400 });
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    return new Response(error.message, { status: 500 });
+  }
+
+  const expo = new Expo();
+  const expoMessages: any[] = [];
+  const webTokens: string[] = [];
+
+  for (const row of data ?? []) {
+    const tokens = row.push_token || {};
+    if (tokens.expo) {
+      expoMessages.push({ to: tokens.expo, title: payload.title, body: payload.body });
+    }
+    if (tokens.web) {
+      webTokens.push(tokens.web);
+    }
+  }
+
+  if (expoMessages.length) {
+    await expo.sendPushNotificationsAsync(expoMessages);
+  }
+
+  if (webTokens.length && fcmKey) {
+    for (const token of webTokens) {
+      await fetch('https://fcm.googleapis.com/fcm/send', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `key=${fcmKey}`,
+        },
+        body: JSON.stringify({
+          to: token,
+          notification: { title: payload.title, body: payload.body },
+        }),
+      });
+    }
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+});


### PR DESCRIPTION
## Summary
- add FCM service worker for web notifications
- store both Expo and web push tokens
- trigger push notifications on messages and urgent jobs via Supabase edge function

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c868c020832497c3348c3265aada