### PR TITLE
feat: add PWA support for web build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Web deployment
+
+To create a production web build with the custom service worker, run:
+
+```bash
+npm run build:web
+```
+
+Deploy the generated `web-build` directory to a hosting provider such as Netlify, Vercel, or Supabase Hosting, and map your desired domain via DNS.

--- a/app.json
+++ b/app.json
@@ -48,6 +48,12 @@
     },
     "updates": {
       "url": "https://u.expo.dev/41096993-00de-4595-960d-c5e6fe1c40f8"
+    },
+    "web": {
+      "favicon": "./assets/images/favicon.png",
+      "themeColor": "#4CAF50",
+      "backgroundColor": "#ffffff",
+      "display": "standalone"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "build:web": "expo build:web"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" href="/assets/images/favicon.png" />
+    <meta name="theme-color" content="#4CAF50" />
+    <title>Agri-Crew</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/service-worker.js');
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agri-Crew",
+  "short_name": "AgriCrew",
+  "icons": [
+    {
+      "src": "/assets/images/icon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/images/adaptive-icon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#4CAF50",
+  "background_color": "#ffffff"
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,14 @@
+const CACHE_NAME = 'agricrew-cache-v1';
+const urlsToCache = ['/', '/index.html'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web config to app.json with favicon, theme, and standalone display
- create manifest, custom service worker, and index.html for PWA
- document web build and add build script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4c86654588324871e4d686e0c26c0